### PR TITLE
Fixed video url of file

### DIFF
--- a/apps/editar/modules/files/templates/infoSuccess.php
+++ b/apps/editar/modules/files/templates/infoSuccess.php
@@ -90,7 +90,7 @@
   <br />
   <?php echo label_for('embed', __('Serie:'), 'class="required" ') ?>
   <div class="content">
-    <input type="text" onclick="this.select()" size="80" value="<?php echo $file->getMm()->getUrl(true) ?>" />   
+    <input type="text" onclick="this.select()" size="80" value="<?php echo $file->getMm()->getSerial()->getUrl(true) ?>" />   
   </div>
 </div>
 

--- a/lib/model/File.php
+++ b/lib/model/File.php
@@ -135,7 +135,7 @@ class File extends BaseFile
   public function getUrlLink($absolute = false)
   {
     $host = ($absolute)?sfConfig::get('app_info_link'):''; 
-    return ($host . '/es/video/' . $this->getId() . '.html');
+    return ($host . '/es/video/' . $this->getMm()->getId() . '.html');
   }
 
 


### PR DESCRIPTION
Backend
'File' edit: 'URL'
- Field ' Video'
- Field 'Serie'

As it were before:
- 'Video' shows an url for a specific 'file'. This URL returns 404 error. With this pull request, it shows an url for the multimedia object. This URL shows the public video of this multimedia object, although it is not necessarily the video we want to watch.
- 'Series' shows an url for the multimedia object. This URL shows the public video of this multimedia object, but it is not necessarily the video we want to watch. Besides, it should show the url for the series.
